### PR TITLE
[FEAT] MSA환경에 올라가기 위한 팀 컨벤션 api구조로 변경

### DIFF
--- a/src/main/java/com/example/SchoolLunchReport/dummy/dataset/controller/DatasetController.java
+++ b/src/main/java/com/example/SchoolLunchReport/dummy/dataset/controller/DatasetController.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 @RestController
-@RequestMapping("/api/team3/dataset/")
+@RequestMapping("/api/team3/analytics/dataset")
 public class DatasetController {
 
     private final DatasetService datasetService;

--- a/src/main/java/com/example/SchoolLunchReport/statistics/rank/controller/RankController.java
+++ b/src/main/java/com/example/SchoolLunchReport/statistics/rank/controller/RankController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/menu")
+@RequestMapping("/api/team3/analytics/menu")
 @RequiredArgsConstructor
 public class RankController implements RankControllerDocs {
 


### PR DESCRIPTION
### MSA환경에 올라가기 위한 팀 컨벤션 api구조로 변경

현재 존재하는 2개 컨트롤러 모두
base url은 /api/team3/analytics/ -> 가 앞에 붙습니다.

- 상윤님이 만드신 컨트롤러
/api/team3/analytics/menu

- 제가 만든 컨트롤러
/api/team3/analytics/dataset

=> 위와 같이 base url 수정되었습니다.

스프링 프로세스가 한 파드로, 장고가 또 한 파드로 올라갈거고
스프링부트 내에 다수의 컨트롤러는 /api/team3/analytics/{도메인별 네임} 이렇게 네이밍되어 올라갈 예정입니다.